### PR TITLE
Fix compatibility with MantisBT 2.27+ db_query() signature change

### DIFF
--- a/core/request_api.php
+++ b/core/request_api.php
@@ -72,7 +72,7 @@ function request_count() {
 	$t_requests_table = plugin_table( 'requests' );
 
 	$t_query = "SELECT count(*) FROM $t_requests_table";
-	$t_result = db_query( $t_query, null );
+	$t_result = db_query( $t_query );
 
 	$t_count = db_result( $t_result );
 
@@ -97,7 +97,7 @@ function request_get_page( $p_page_id, $p_per_page ) {
 	$t_offset = ( $p_page_id - 1 ) * $p_per_page;
 
 	$t_query = "SELECT * FROM $t_requests_table ORDER BY timestamp DESC";
-	$t_result = db_query( $t_query, null, $p_per_page, $t_offset );
+	$t_result = db_query( $t_query, [], $p_per_page, $t_offset );
 
 	$t_requests = array();
 


### PR DESCRIPTION
Recent changes in MantisBT introduced strict typing to the `db_query()` function, making the `$p_params` argument a **non-nullable `array`**. As a result, passing `null` now triggers a fatal `TypeError`:

```
db_query(): Argument #2 ($p_params) must be of type array, null given
```

This PR fixes the crash on the Eventlog plugin index page by replacing `null` with an empty array (`[]`) or by omitting the argument when no parameters are required. This ensures compatibility with the latest MantisBT release and prevents the runtime error.
