### PR TITLE
use short-form (int) cast instead of (integer)

### DIFF
--- a/core/request_api.php
+++ b/core/request_api.php
@@ -103,9 +103,9 @@ function request_get_page( $p_page_id, $p_per_page ) {
 
 	while ( $t_row = db_fetch_array( $t_result ) ) {
 		$t_request = new EventLogRequest();
-		$t_request->id = (integer)$t_row['id'];
-		$t_request->user_id = (integer)$t_row['user_id'];
-		$t_request->timestamp = (integer)$t_row['timestamp'];
+		$t_request->id = (int)$t_row['id'];
+		$t_request->user_id = (int)$t_row['user_id'];
+		$t_request->timestamp = (int)$t_row['timestamp'];
 
 		$t_requests[] = $t_request;
 	}

--- a/pages/index.php
+++ b/pages/index.php
@@ -23,7 +23,7 @@ layout_page_begin();
 
 $t_per_page = 100;
 $t_total_count = request_count();
-$t_total_pages_count = (integer)(( $t_total_count + ( $t_per_page - 1 ) ) / $t_per_page);
+$t_total_pages_count = (int)(( $t_total_count + ( $t_per_page - 1 ) ) / $t_per_page);
 
 $t_requests = request_get_page( $f_page_id, $t_per_page );
 $t_formatted_requests = request_format( $t_requests );


### PR DESCRIPTION
## Summary
- Replaces the long-form `(integer)` type cast with the short-form `(int)` cast in two files
- Purely a style/consistency change — no behavioral difference (the two casts are aliases in PHP)
- Aligns the codebase with the PSR / PHP-FIG convention which recommends the short cast keywords

## Files Changed
- `core/request_api.php` — three casts inside `request_get_page()` (id, user_id, timestamp)
- `pages/index.php` — one cast computing `$t_total_pages_count`